### PR TITLE
Dev monitoring portforward

### DIFF
--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +56,12 @@ var forwardCmd = &cobra.Command{
                 time.Sleep(5 * time.Second)
                 continue
             }
+
+            // Open the Argo UI in the default browser
+            browser.OpenURL("http://localhost:10000")
+
             // Implement a check to see if the port-forwarding is still active
+
         }
     },
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module ae-cli-tool
 
-go 1.21.4
+go 1.21
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.0
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,14 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 h1:X/2sJAybVknnUnV7AD2HdT6rm2p5BP6eH2j+igduWgk=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This pull request introduces two key enhancements to the `ae-cli-tool`:

1.     Automated Monitoring of Port Forwarding: Implemented `monitorPortForward` to continuously monitor and restart the kubectl port-forward process if it stops unexpectedly, improving reliability.
2.     Automatic Browser Opening: Integrated functionality to automatically open the Argo UI in the default browser upon successful establishment of port forwarding, enhancing user convenience.

These changes aim to streamline the user experience and ensure consistent access to Kubernetes services.